### PR TITLE
Fixed padding bug in svg-inline mixing

### DIFF
--- a/components/_patterns/01-atoms/svg/_svg__mixins.scss
+++ b/components/_patterns/01-atoms/svg/_svg__mixins.scss
@@ -146,9 +146,9 @@
     transform-style: preserve-3d;
 
     @if ($h-alignment == 'left') {
-      left: 0 + $svg-pad-left + $container-padding-left;
+      left: 0 + $svg-pad-left + ($svg-width / 2) + $container-padding-left;
     } @else {
-      right: 0 + $svg-pad-right;
+      right: 0 + $svg-pad-right - ($svg-width / 2) + $container-padding-right;
     }
 
     // SVG vertical positioning


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fosterinteractive/mainspring/7)
<!-- Reviewable:end -->
